### PR TITLE
Re-organization of tut pages, white buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # TutorialPages
-Rainbow-themed responsive tutorial webpage project built using HTML, CSS, Boostrap and JQuery
+Rainbow-themed responsive tutorial webpage project built using HTML, CSS, Boostrap and JQuer


### PR DESCRIPTION
This edit has color-changing black buttons (change to white on mouse over) using a swap feature from Bootstrap. In addition, the next button within each math 7 topic links to the next topic page, and then back to the 7th grade math topics, and the same goes for the one comp sci topic and Graphic Design.
"Links Reference" on all pages has been change to the title "Lesson Reference Links"
The HTML pages for tutorial topics have all been organized within one TUtorial_Topics folder, with sub folders for topics, and the other pages, as well as any "Lesson Reference Links" have had links updated to redirect to the correct HTML page